### PR TITLE
Lid State Fix

### DIFF
--- a/PsNee.ino
+++ b/PsNee.ino
@@ -305,7 +305,7 @@ void inject_playstation()
   pinMode(gate, INPUT);
   pinMode(data, INPUT);
 }
- 
+
 //!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 //--------------------------------------------------
 //     Setup function - execution starts here!
@@ -320,9 +320,11 @@ void setup()
 //----------------------------------------------------------------
 void loop()
 {
-  if(lid == 0)
+ 
+  if(digitalRead(lid) == 0)
   {
-    while(lid != 1);      //Wait until the lid is closed again (after being opened) to initiate a new injection cycle
+    while(digitalRead(lid) != 1)      //Wait until the lid is closed again (after being opened) to initiate a new injection cycle
+     
     inject_playstation();
   }
 }

--- a/PsNee.ino
+++ b/PsNee.ino
@@ -319,12 +319,10 @@ void setup()
 //   Loop function - executes after the initial injection cycle
 //----------------------------------------------------------------
 void loop()
-{
- 
+{ 
   if(digitalRead(lid) == 0)
   {
-    while(digitalRead(lid) != 1)      //Wait until the lid is closed again (after being opened) to initiate a new injection cycle
-     
+    while(digitalRead(lid) != 1)      //Wait until the lid is closed again (after being opened) to initiate a new injection cycle     
     inject_playstation();
   }
 }

--- a/PsNee.ino
+++ b/PsNee.ino
@@ -305,6 +305,7 @@ void inject_playstation()
   pinMode(gate, INPUT);
   pinMode(data, INPUT);
 }
+
 //!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 //--------------------------------------------------
 //     Setup function - execution starts here!

--- a/PsNee.ino
+++ b/PsNee.ino
@@ -305,7 +305,6 @@ void inject_playstation()
   pinMode(gate, INPUT);
   pinMode(data, INPUT);
 }
-
 //!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 //--------------------------------------------------
 //     Setup function - execution starts here!
@@ -319,7 +318,7 @@ void setup()
 //   Loop function - executes after the initial injection cycle
 //----------------------------------------------------------------
 void loop()
-{ 
+{
   if(digitalRead(lid) == 0)
   {
     while(digitalRead(lid) != 1)      //Wait until the lid is closed again (after being opened) to initiate a new injection cycle     


### PR DESCRIPTION
Previously in the main loop, the lid state was checked for open vs closed in order to inject the SCEx data at the right moment for multi-disk games. However, the loop checks the lid pin number not the value on the lid pin input, which requires a digitalRead.

Change is untested.