### PR TITLE
Add support for Arduino Nano Every / ATtmega4809

### DIFF
--- a/PSNee_V8.6/PSNee_V8.6/PSNee_V8.6.ino
+++ b/PSNee_V8.6/PSNee_V8.6/PSNee_V8.6.ino
@@ -30,7 +30,8 @@
 //#define ATmega328_168  
 //#define ATmega32U4_16U4
 //#define ATtiny85_45_25 
-
+//#define ATmega4809
+ 
 /*  
   Fuses: 
   ATmega - H: DF, L: EE, E: FD. 
@@ -57,6 +58,19 @@
   Pin6-SUBQ (MISO)
   Pin7_DATA (SCK)
   Pin8-VCC
+
+  Pinout Arduino Nano Every:
+  VCC-3.5v, PinGND-GND, 
+  D2(PA0)-BIOS AX (Only for Bios patch)
+  D3(PF5)-BIOS AY (Only for BIOS ver. 1.0j-1.1j)
+  D4(PC6)-BIOS DX (Only for Bios patch)
+  D5(PB2)-Switch* (Optional for Bios patch)
+  D6(PF4)-SQCK
+  D7(PA1)-SUBQ
+  D8(PE3)-DATA
+  D9(PB0)-GATE_WFCK
+  D13(PE2)-LED (Built-in LED)
+  RST-RESET* (Only for JAP_FAT)
 */
   
 
@@ -119,6 +133,10 @@ ISR(CTC_TIMER_VECTOR) {
     millisec++;
     count_isr = 0;
   }
+#if defined(ATmega4809)
+  // Clear TCB0 capture/interrupt flag to allow next interrupt
+  TCB0.INTFLAGS = TCB_CAPT_bm;
+#endif
 }
 
 // *****************************************************************************************
@@ -144,7 +162,7 @@ ISR(CTC_TIMER_VECTOR) {
 //
 // *****************************************************************************************
 void Timer_Start() {
-#if defined(ATmega328_168) || defined(ATmega32U4_16U4) || defined(ATtiny85_45_25)
+#if defined(ATmega328_168) || defined(ATmega32U4_16U4) || defined(ATtiny85_45_25) || defined(ATmega4809)
   TIMER_TCNT_CLEAR;
   TIMER_INTERRUPT_ENABLE;
   #if defined(BIOS_PATCH)
@@ -168,7 +186,7 @@ void Timer_Start() {
 // *****************************************************************************************
 void Timer_Stop() {
   
-  #if defined(ATmega328_168) || defined(ATmega32U4_16U4) || defined(ATtiny85_45_25)
+  #if defined(ATmega328_168) || defined(ATmega32U4_16U4) || defined(ATtiny85_45_25) || defined(ATmega4809)
     TIMER_INTERRUPT_DISABLE;  // Disable timer interrupts to stop counting
     TIMER_TCNT_CLEAR;         // Reset the timer counter to ensure proper timing when restarted
   #endif
@@ -286,7 +304,11 @@ void inject_SCEX(const char region) {
 }
 
 void Init() {
-#if defined(ATmega328_168) || defined(ATmega32U4_16U4) || defined(ATtiny85_45_25)
+#if defined(ATmega4809)
+ SET_CLOCK;
+#endif
+
+#if defined(ATmega328_168) || defined(ATmega32U4_16U4) || defined(ATtiny85_45_25) || defined(ATmega4809)
   TIMER_TCNT_CLEAR;
   SET_OCROA_DIV;
   SET_TIMER_TCCROA;

--- a/PSNee_V8.6/PSNee_V8.6/PSNee_V8.6.ino
+++ b/PSNee_V8.6/PSNee_V8.6/PSNee_V8.6.ino
@@ -369,9 +369,11 @@ int main() {
   // WFCK: __-_-_-_-_-_-_-_-_-_-_-_-  // this is a PU-22 or newer board!
   // typical readouts PU-22: highs: 2449 lows: 2377
   //************************************************************************
+  uint32_t last_read;
   do {
     if (PIN_WFCK_READ == 0) lows++;             // good for ~5000 reads in 1s
-    _delay_us(200);
+    last_read = microsec;
+    while (microsec - last_read < 200) { }
   } 
   while (millisec < 1000);                     // sample 1s
 


### PR DESCRIPTION
This adds support for the Arduino Nano Every, with a ATmega4809 based board.

It doesn't appear to have been wildly popular, but I had a couple around and I thought it would be interesting to add support for it to the PsNee. It is pin compatible with the Arduino Nano, so the pinout would be the same as the Nano.

The ATmega4809 can run with an oscillator speed of 20 MHz or 16 MHz. The Nano Every comes with the fuses set for 16 MHz operation by default, so I left it like that. The CPU divider registry does have to be set at boot to prevent it from running with its default clock divider of 1:6. We also need to clear the interrupt flag on every timer interrupt, those where the only two changes needed to add support for it that fall outside of MUC.h.

I tested this successfully on a PAL SCPH-7502 / PU-22. Unfortunately I don't have any Japanese PS1, so I wasn't able to test the BIOS patch.

This PR also has a fix for the board detection loop: when testing I found that interrupts / timers add a massive overhead to the delay functions, so lows were being undercounted. In my Nano and Nano Every, _delay_ms(200) would actually take about 600 us of wall time. With this fix, the low count is now very consistent and matches the expected count of ~2500 (I have a PU-22).