### PR TITLE
[WIP] Add RP2040 support

### DIFF
--- a/PSNee/MCU.h
+++ b/PSNee/MCU.h
@@ -864,3 +864,84 @@ static inline void optimizePeripherals(void) {
 
 #endif
 
+#ifdef RP2040
+
+  #include <stdint.h>
+  #include <stdbool.h>
+  #include <pico/stdlib.h>
+
+  // Main pin configuration
+
+  // Define the main pins as inputs
+  #define RP2040_INPUT(gpio) (gpio_set_dir(gpio, false))
+  #define PIN_DATA_INPUT RP2040_INPUT(4)    // Set GPIO4 as input
+  #define PIN_WFCK_INPUT RP2040_INPUT(5)    // Set GPIO5 as input
+  #define PIN_SQCK_INPUT RP2040_INPUT(6)    // Set GPIO6 as input
+  #define PIN_SUBQ_INPUT RP2040_INPUT(7)    // Set GPIO7 as input
+  
+  // Enable pull-ups and set high on the main pins
+  #define RP2040_OUTPUT(gpio) (gpio_set_dir(gpio, true))
+  #define PIN_DATA_OUTPUT RP2040_OUTPUT(4)  // Set GPIO4 as output
+  #define PIN_WFCK_OUTPUT RP2040_OUTPUT(5)  // Set GPIO5 as output
+  
+  // Define pull-ups and set high at the main pin
+  #define RP2040_SET(gpio, high) (gpio_put(gpio, high))
+  #define PIN_DATA_SET RP2040_SET(4, true)    // Set GPIO4 high
+  
+  // Clear the main pins (set low)
+  #define PIN_DATA_CLEAR RP2040_SET(4, false) // Set GPIO4 low
+  #define PIN_WFCK_CLEAR RP2040_SET(5, false) // Set GPIO5 low
+  
+  // Read the state of the main input pins
+  #define RP2040_READ(gpio) (gpio_get(gpio))
+  #define PIN_WFCK_READ RP2040_READ(5)  // Check if the value of GPIO5 is high (1)
+  #define PIN_SQCK_READ RP2040_READ(6)  // Check if the value of GPIO6 is high (1)
+  #define PIN_SUBQ_READ RP2040_READ(7)  // Check if the value of GPIO7 is high (1)
+
+  // LED pin handling (for indication)
+  #ifdef LED_RUN
+    #define PIN_LED_OUTPUT  RP2040_OUTPUT(25)  // Configure GPIO25 as output (builtin LED)
+    #define PIN_LED_ON      RP2040_SET(25, true)  // Set GPIO25 high (turn on LED)
+    #define PIN_LED_OFF     RP2040_SET(25, false)  // Set GPIO25 low (turn off LED)
+  #endif
+
+  // Handling the BIOS patch
+  #if defined(SCPH_102) || defined(SCPH_100) || defined(SCPH_7500_9000) || defined(SCPH_7000) || defined(SCPH_5000_5500) || defined(SCPH_3500) || defined(SCPH_3000) || defined(SCPH_1000)
+
+    // Define input pins for the BIOS patch
+    #define PIN_AX_INPUT RP2040_INPUT(8)        // Set GPIO8 as input
+    #define PIN_DX_INPUT RP2040_INPUT(9)        // Set GPIO9 as input
+
+    // Define output pins for the BIOS patch
+    #define PIN_DX_OUTPUT RP2040_OUTPUT(9)      // Set GPIO9 as output
+
+    // Set pull-ups high on output pins
+    #define PIN_DX_SET RP2040_SET(9, true)      // Set GPIO9 high
+
+    // Set pull-ups low on output pins
+    #define PIN_DX_CLEAR RP2040_SET(9, false)   // Set GPIO4 low
+
+
+    #define WAIT_AX_RISING    (!RP2040_READ(8)) // Attend le début de l'impulsion
+    #define WAIT_AX_FALLING    (RP2040_READ(8)) // Attend la fin de l'impulsion
+
+    // Read the input pins for the BIOS patch
+    #define PIN_AX_READ RP2040_READ(8)          // Check if the value of GPIO8 is high (1)
+
+    // Defin PIN_AY for HIGH_PATCH
+    #if defined(SCPH_3000) || defined(SCPH_1000)
+      #define PIN_AY_INPUT RP2040_INPUT(10)        // Set GPIO10 as input
+      #define WAIT_AY_RISING     (!RP2040_READ(10)) // AY est sur GPIO10
+      #define WAIT_AY_FALLING    (RP2040_READ(10))
+ 
+    #endif
+      // Handle switch input for BIOS patch
+    #if defined(SCPH_7000)
+      #define PIN_SWITCH_INPUT RP2040_INPUT(11)        // Set GPIO11 as input
+      #define PIN_SWITCH_SET RP2040_SET(11, true)      // Set GPIO11 high
+      #define PIN_SWITCH_READ RP2040_READ(11)          // Check if the value of GPIO11 is high (1)
+    #endif
+
+  #endif
+
+#endif

--- a/PSNee/PSNee.ino
+++ b/PSNee/PSNee.ino
@@ -197,7 +197,7 @@ void board_detection() {
       */
       if (!PIN_WFCK_READ) {
         wfck_mode = 1; // Target: PU-22 or newer
-        return;
+        break;
       }
     }
   }

--- a/PSNee/PSNee.ino
+++ b/PSNee/PSNee.ino
@@ -120,10 +120,14 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
                          pointer and variable section
 ------------------------------------------------------------------------------------------------*/
 
+#ifdef RP2040
+  #include "RP2040_MCU.h"
+#else
+  #include <util/delay.h>
+#endif
 #include "MCU.h"
 #include "settings.h"
 #include "BIOS_patching.h"
-#include <util/delay.h>
 
 
 //Flag initializing for automatic console generation selection 0 = old, 1 = pu-22 end  ++
@@ -500,6 +504,8 @@ void Init() {
   #if defined(PSNEE_DEBUG_SERIAL_MONITOR) && defined(ATtiny85_45_25)
     //pinMode(debugtx, OUTPUT); // software serial tx pin
     mySerial.begin(115200); // 13,82 bytes in 12ms, max for softwareserial. (expected data: ~13 bytes / 12ms) // update: this is actually quicker
+  #elif defined(PSNEE_DEBUG_SERIAL_MONITOR) && defined(RP2040)
+    Serial.begin(115200);
   #elif defined(PSNEE_DEBUG_SERIAL_MONITOR) && !defined(ATtiny85_45_25)
     Serial.begin(500000); // 60 bytes in 12ms (expected data: ~26 bytes / 12ms) // update: this is actually quicker
   #endif
@@ -508,10 +514,20 @@ void Init() {
   board_detection();
 }
 
-int main() {
+#ifdef RP2040
+void loop() {}
 
+void setup()
+#else
+int main()
+#endif
+{
+
+#ifdef RP2040
+  start_rp2040();
+#endif
+  
   Init();
-
 
   while (1) {
 

--- a/PSNee/RP2040_MCU.h
+++ b/PSNee/RP2040_MCU.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <pico/stdlib.h>
+#include <stdint.h>
+
+void start_rp2040()
+{
+    //Enabling this line will reproduce 16MHz as the Arduino (in theory), but the serial will be disabled.
+    //set_sys_clock_pll(882000000, 7, 7); //16MHz clock
+    const uint32_t gpio_pins_mask = (0xf << 4) | (1U << 25);
+    gpio_init_mask(gpio_pins_mask);
+}
+
+void _delay_ms(double ms)
+{
+    sleep_ms(ms);
+}
+
+void _delay_us(double us)
+{
+    sleep_us(us);
+}

--- a/PSNee/settings.h
+++ b/PSNee/settings.h
@@ -253,11 +253,13 @@ void Debug_Inject(){       // Confirmation of region code injection
 
 #if !defined(ATmega328_168)   && \
     !defined(ATmega32U4_16U4) && \
-    !defined(ATtiny85_45_25)
+    !defined(ATtiny85_45_25) && \
+    !defined(RP2040)
  #error "MCU not selected! Please choose one"
 #elif !defined(ATmega328_168)    ^ \
        defined(ATmega32U4_16U4 ) ^ \
-       defined(ATtiny85_45_25)
+       defined(ATtiny85_45_25 ) ^ \
+       defined(RP2040)
  #error "May be selected only one MCU"
 #endif
 


### PR DESCRIPTION
# Description

This add support for the RP2040, which also adds support to many dev-boards like the Raspberry Pi Pico (official dev board) and many many many Chinese clones. There are some of them at the same size of a ATTiny85 dev-board and extremely cheap too, but with the powerhouse of multiples Arduino Uno

## Changes

To the moment, I just added the MCU defines. No main code was touched except for the main() function because I'm using the default "Arduino" bootloader for the RP2040. I mimicked the AVR functions with some from the Pico SDK. I'm not sure if there would be any issue with timing but, if there could be, then we could use PIO.

## Testings

I used the WeAct studio dev-board (full size dev-board, almost the same as the official one) and the RP2040-Zero (micro size dev-board, just like a ATTiny85 dev-board). For the console, I used the SCPH-9001 with PU-23 (1-674-987-51). I also plan to use some PM-41 but I'm waiting for the disc drive replacement.

## Compiling

Beside from Arduino (core), you also need to have the [arduino-pico](https://github.com/earlephilhower/arduino-pico) boards installed. Then, for the board, you have to select `Raspberry Pi Pico (2040)` even if you're using a Chinese clone available from the list. The rest you have to leave it with the default values.

If you're using Visual Studio Code, then you can use this arduino.json:

```json
{
    "sketch": "PSNee/PSNee.ino",
    "configuration": "flash=2097152_0,freq=200,opt=Small,os=none,profile=Disabled,rtti=Disabled,stackprotect=Disabled,exceptions=Disabled,dbgport=Disabled,dbglvl=None,usbstack=picosdk,ipbtstack=ipv4only,uploadmethod=default",
    "board": "rp2040:rp2040:rpipico",
    "output": "./.build"
}
```

## Pinout

The used pins are from 4 to 11 (both included), wired as below:

| Usage | GPIO |
| :--- | :--- |
| DATA | GPIO4 |
| WFCK | GPIO5 |
| SQCK | GPIO6 |
| SUBQ | GPIO7 |
| AX | GPIO8 |
| DX | GPIO9 |
| AY | GPIO10 |
| Switch | GPIO11 |

## Testing results

For now I've tested the boot up sequence. I managed to display the PS logo with the SCEA banner, then followed with a black screen (not sure if this was because an issue with PSNee, with my console, or with the disc itself, I'm still digging about that). Though it was a 50/50 for now, as the first boot-up it seems to skip the PSNee and just went right into the Memory Card manager (as if the lid was open), but after pressing the Reset button (the small button of the PS Fat) it went directly into the PS Logo.

I have to do further testing with another disc and check if this was an isolated error or if I have to improve the bootloader

## TODO list

- [ ] Implement BIOS Patching (Pinout is defined, but not tested)
- [ ] Test selecting exact board model instead of using SCPH-XXXX
- [ ] Test with PM-41
- [ ] Get almost 100% of fidelity just like with the Arduino Uno/ATmega328P