### PR TITLE
#feature: Forced Reset Synchronization for BIOS Patching Stability and Bootloader preservation (PS1 JAP / European PSOne)

### DIFF
--- a/PSNee/MCU.h
+++ b/PSNee/MCU.h
@@ -199,7 +199,7 @@
   #include <avr/interrupt.h>
   #include <avr/sfr_defs.h>
   #include <util/delay.h>
-
+  #include <avr/wdt.h>
 
 
   // Main pin configuration
@@ -256,7 +256,7 @@
     #define PIN_AX_INTERRUPT_DISABLE    EIMSK  &= ~(1<<INT0)      // Disable external interrupt on INT0
     #define PIN_AX_INTERRUPT_RISING     EICRA  |=  (1<<ISC01)|(1<<ISC00)                  // Configure INT0 for rising edge trigger
     #define PIN_AX_INTERRUPT_VECTOR     INT0_vect               // Interrupt vector for INT0 (external interrupt)
-    #define PIN_AX_INTERRUPT_CLEAR      EIFR |= (1 << INTF0)  
+    #define PIN_AX_INTERRUPT_CLEAR      EIFR |= (1 << INTF0)
 
     // Secondary Address line (AY) for multi-stage patching (INT1)
     #if defined(SCPH_3000) || \
@@ -274,12 +274,19 @@
     #endif
 
      // Hardware Bypass Switch (On-the-fly deactivation)
-    #ifdef PATCH_SWITCHE
+    #ifdef PATCH_SWITCH
       #define PIN_SWITCH_INPUT DDRD &= ~(1 << DDD5)  // Configure PIND5 as input for switch
       #define PIN_SWITCH_SET   PORTD |= (1 << PD5)     // Set PIND5 high (enable pull-up)
       #define PIN_SWITCH_READ (!!(PIND & (1 << PIND5)))  // Read the state of PIND5 (switch input)
     #endif
 
+    // AUTO BOOT RESET (D10 / PB2)
+    #ifdef ENABLE_HOLD_RESET_ON_BOOT
+      #define PIN_HRS_OUTPUT DDRB |= (1 << DDB2)  // Set PINB2 as output
+      #define PIN_HRS_INPUT  DDRB &= ~(1 << DDB2) // Set PINB2 as input -High Impedance-
+      #define PIN_HRS_LOW    PORTB &= ~(1 << PB2) // Set PINB2 low (force reset active)
+      #define PIN_HRS_PRESSED (!(PINB & (1 << PB2))) 
+    #endif
   #endif
 
   // #if defined(DEBUG_SERIAL_MONITOR)
@@ -360,6 +367,7 @@
   #include <avr/interrupt.h>
   #include <avr/sfr_defs.h>
   #include <util/delay.h>
+  #include <avr/wdt.h>
 
 
 
@@ -440,10 +448,18 @@
     #endif
 
     // Hardware Bypass Switch (On-the-fly deactivation)
-    #ifdef PATCH_SWITCHE
+    #ifdef PATCH_SWITCH
       #define PIN_SWITCH_INPUT DDRC  &= ~(1 << DDC6) // Bypass on PC6
       #define PIN_SWITCH_SET   PORTC |=  (1 << PC6)  // Enable pull-up
       #define PIN_SWITCH_READ  (!!(PINC & (1 << PINC6)))
+    #endif
+
+    // AUTO BOOT RESET (A0 / PF7)
+    #ifdef ENABLE_HOLD_RESET_ON_BOOT
+      #define PIN_HRS_OUTPUT DDRF |= (1 << DDF7)  // Set A0 as output
+      #define PIN_HRS_INPUT  DDRF &= ~(1 << DDF7) // Set A0 as input -High Impedance-
+      #define PIN_HRS_LOW    PORTF &= ~(1 << PF7) // Set A0 low (active force reset)
+      #define PIN_HRS_PRESSED (!(PINF & (1 << PF7)))
     #endif
   #endif
 #endif

--- a/PSNee/PSNee.ino
+++ b/PSNee/PSNee.ino
@@ -33,7 +33,7 @@
 // #define SCPH_102             // DX - D0  | AX - A7          |                  | 4.4e - CRC 0BAD7EA9, 4.5e -CRC 76B880E5
 // #define SCPH_100             // DX - D0  | AX - A7          |                  | 4.3j - CRC F2AF798B
 // #define SCPH_7000_7500_9000  // DX - D0  | AX - A7          |                  | 4.0j - CRC EC541CD0
-// #define SCPH_3500_5000_5500  // DX - D0  | AX - A16         | AX - A15         | 3.0j - CRC FF3EEB8C, 2.2j - CRC 24FC7E17, 2.1j - CRC BC190209 
+#define SCPH_3500_5000_5500  // DX - D0  | AX - A16         | AX - A15         | 3.0j - CRC FF3EEB8C, 2.2j - CRC 24FC7E17, 2.1j - CRC BC190209 
 // #define SCPH_3000            // DX - D5  | AX - A7, AY - A8 | AX - A6, AY - A7 | 1.1j - CRC 3539DEF6 
 // #define SCPH_1000            // DX - D5  | AX - A7, AY - A8 | AX - A6, AY - A7 | 1.0j - CRC 3B601FC8
 
@@ -65,12 +65,22 @@
  * - ATmega32U4 (Pro Micro): Connect LED between PB6 (Pin 10) and GND.
  */
 
-//#define PATCH_SWITCHE    // This allows the user to disable the BIOS patch on-the-fly.
+//#define PATCH_SWITCH    // This allows the user to disable the BIOS patch on-the-fly.
 /*
  * This allows you to bypass the memory card blocking problems on the SCPH-7000.
  * - Configure Pin D5 as Input.
  * - Enable internal Pull-up.
  * - Exit immediately the patch BIOS if the switch pulls the pin to GND
+ */
+
+#define ENABLE_HOLD_RESET_ON_BOOT
+ /* 
+ * Holds PS1 reset on boot for more stability in BIOS PATCH for all JAP PS1 and European SCHP-102. D10 for ATMEGA328. A0 for ATMEGA32U4. 
+ * This also makes possible to preserve the bootloader without needing a programmer.
+ * Caution: 
+ * FAT Models. Instead of connecting PS1's reset line to RST connect it to D10 (ATMEGA328) or A0 (ATMEGA32U4) in Arduino.
+ * This needs a power cycle for stability. The use of manually pressing PS1's reset button or IGR mod leads to instability in BIOS PATCH (hit and miss). 
+ * SLIM Models. Connect PS1's reset line to D10 (ATMEGA328) or A0 (ATMEGA32U4) in Arduino.
  */
 
 // #define DEBUG_SERIAL_MONITOR  // Enables serial monitor output. 
@@ -136,6 +146,8 @@ uint8_t wfck_mode = 0;  //Flag initializing for automatic console generation sel
 uint8_t SUBQBuffer[12]; // Global buffer to store the 12-byte SUBQ channel data
 
 uint8_t request_counter = 0;
+
+uint8_t flag_switch = 0;
 
 #if defined(DEBUG_SERIAL_MONITOR)
   uint16_t global_window = 0; // Stores the remaining cycles from the detection window
@@ -243,18 +255,12 @@ uint8_t request_counter = 0;
   void Bios_Patching(void) {
 
       // --- HARDWARE BYPASS OPTION ---
-      #if defined(PATCH_SWITCHE)
-          PIN_SWITCH_INPUT;               // Configure Pin D5 as Input
-          PIN_SWITCH_SET;                 // Enable internal Pull-up (D5 defaults to HIGH)
-          __builtin_avr_delay_cycles(10); // Short delay for voltage stabilization
-          
-          /** 
-          * Exit immediately if the switch pulls the pin to GND (Logic LOW).
-          * This allows the user to disable the BIOS patch on-the-fly.
-          */
-          if (PIN_SWITCH_READ == 0) { 
-              return; 
-          }
+      #if defined(PATCH_SWITCH)
+        if (flag_switch) return;
+      #endif
+
+      #if defined(ENABLE_HOLD_RESET_ON_BOOT)
+        hold_reset(300);
       #endif
 
       uint8_t current_confirms = 0;
@@ -664,10 +670,38 @@ void PerformInjectionSequence(uint8_t injectSCEx) {
   #endif
 }
 
+void hold_reset(uint8_t hold_rst_time){
+    // AUTO BOOT RESET - PIN D10 ATMEGA328/ A0 ATMEGA32U4
+    PIN_HRS_OUTPUT;         // Set as output
+    PIN_HRS_LOW;            // Set GND
+    _delay_ms(hold_rst_time); // Hold reset
+    PIN_HRS_INPUT;          // Set High Impedance
+}
+
 void Init() {
+  // Disable watchdog after reset
+  #if defined(ENABLE_HOLD_RESET_ON_BOOT) && defined(BIOS_PATCH) && (defined(IS_328_168_FAMILY) || defined(IS_32U4_FAMILY))
+    MCUSR = 0;
+    wdt_disable();
+  #endif
 
   #ifdef LED_RUN
     PIN_LED_OUTPUT;
+  #endif
+
+  #if defined(PATCH_SWITCH)
+    flag_switch = 0;
+    PIN_SWITCH_INPUT;               // Configure Pin D5 as Input
+    PIN_SWITCH_SET;                 // Enable internal Pull-up (D5 defaults to HIGH)
+    __builtin_avr_delay_cycles(10); // Short delay for voltage stabilization
+    
+    /** 
+    * Exit immediately if the switch pulls the pin to GND (Logic LOW).
+    * This allows the user to disable the BIOS patch on-the-fly.
+    */
+    if (PIN_SWITCH_READ == 0) { 
+        flag_switch = 1; // saves disable state
+    }
   #endif
 
   // --- Critical Boot Patching ---
@@ -702,8 +736,17 @@ void Init() {
   BoardDetection();
 }
 
-int main() {
+// CAPTURE MANUAL RESET FOR JAP FAT MODELS THAT REQUIRE BIOS PATCH
+void capture_reset(){
+  _delay_ms(50);
+  if (PIN_HRS_PRESSED) {
+    while (PIN_HRS_PRESSED);
+    wdt_enable(WDTO_15MS); 
+    while(1);
+  }
+}
 
+int main() {
   Init();
 
   #if defined(DEBUG_SERIAL_MONITOR)
@@ -712,6 +755,15 @@ int main() {
   #endif
 
   while (1) {
+    // CAPTURE MANUAL RESET FOR JAP FAT MODELS THAT REQUIRE BIOS PATCH
+    #if defined(FAT) && defined(ENABLE_HOLD_RESET_ON_BOOT) && (defined(IS_328_168_FAMILY) || defined(IS_32U4_FAMILY))
+      #ifdef PATCH_SWITCH
+        if (!flag_switch && PIN_HRS_PRESSED) capture_reset();
+      #else
+        if (PIN_HRS_PRESSED) capture_reset();
+      #endif
+    #endif
+
 
     _delay_ms(1);        // Timing Sync: Prevent reading the tail end of the previous SUBQ packet
     

--- a/PSNee/settings.h
+++ b/PSNee/settings.h
@@ -23,6 +23,7 @@
     #define PULSE_COUNT 47         
     #define BIT_OFFSET_CYCLES 47   
     #define OVERRIDE_CYCLES 3       
+    #define SLIM
   #endif
 
 
@@ -33,7 +34,8 @@
     #define CONFIRM_COUNTER_TARGET 1
     #define PULSE_COUNT 15          
     #define BIT_OFFSET_CYCLES 47    
-    #define OVERRIDE_CYCLES 3       
+    #define OVERRIDE_CYCLES 3
+    #define FAT
   #endif
 
   // // ----- SCPH 3500 / 5000 / 5500 -----
@@ -44,6 +46,7 @@
     #define PULSE_COUNT 84
     #define BIT_OFFSET_CYCLES 47
     #define OVERRIDE_CYCLES 3
+    #define FAT
   #endif
 
   // // -------- SCPH 3000 --------
@@ -59,6 +62,7 @@
     #define PULSE_COUNT_2 42
     #define BIT_OFFSET_2_CYCLES 48
     #define OVERRIDE_2_CYCLES 3
+    #define FAT
   #endif
 
 
@@ -75,6 +79,7 @@
     #define PULSE_COUNT_2 70
     #define BIT_OFFSET_2_CYCLES 48
     #define OVERRIDE_2_CYCLES 3
+    #define FAT
   #endif
 #endif
 
@@ -88,7 +93,8 @@
     #define CONFIRM_COUNTER_TARGET 8
     #define PULSE_COUNT 47 
     #define BIT_OFFSET_CYCLES 47 
-    #define OVERRIDE_CYCLES 3       
+    #define OVERRIDE_CYCLES 3
+    #define SLIM   
   #endif
 
 
@@ -99,7 +105,8 @@
     #define CONFIRM_COUNTER_TARGET 1
     #define PULSE_COUNT 15    
     #define BIT_OFFSET_CYCLES 47  
-    #define OVERRIDE_CYCLES 3       
+    #define OVERRIDE_CYCLES 3
+    #define FAT
   #endif
 
   // // ----- SCPH 3500 / 5000 / 5500 -----
@@ -110,6 +117,7 @@
     #define PULSE_COUNT 84      
     #define BIT_OFFSET_CYCLES 47 
     #define OVERRIDE_CYCLES 3
+    #define FAT
   #endif
 
   // // -------- SCPH 3000 --------
@@ -125,6 +133,7 @@
     #define PULSE_COUNT_2 42
     #define BIT_OFFSET_2_CYCLES 48
     #define OVERRIDE_2_CYCLES 3
+    #define FAT
   #endif
 
 
@@ -141,6 +150,7 @@
     #define PULSE_COUNT_2 70
     #define BIT_OFFSET_2_CYCLES 48
     #define OVERRIDE_2_CYCLES 3
+    #define FAT
   #endif
 #endif
 


### PR DESCRIPTION
## Description
This introduces a simple hardware reset synchronization mechanism to resolve the timing issues often encountered when patching the BIOS on late PS1 models (such as the SCPH-102 / PM-41 board) and Japanese consoles.

It also includes an update to the installation diagrams to document the new reset point for the PM-41 board.

## The Problem: The "Race Condition"
On consoles requiring real-time BIOS patching (AX/DX bus), the MCU initialization delay (and bootloader wait time) can cause it to miss the start of the BIOS execution. This results in:
* Random black screens on boot.
* Failed multi-region boots.
* Inconsistent behavior on cold starts.

## The Solution: Forced Boot Sync
I have implemented an optional synchronization mechanism. When enabled, the Arduino takes control of the console’s reset line during the boot sequence:
1. **Pulse:** The Arduino pulls the console's reset line **LOW** immediately upon power-up.
2. **Hold:** This forces the PS1 to stay in a reset state while the MCU initializes and prepares the `Bios_Patching()` routine.
3. **Release:** Once the Arduino is ready to intercept the bus, it releases the line (High Impedance), allowing the console to boot with the patcher already active.

## Implementation Details
* **Toggle:** Controlled via `#define ENABLE_HOLD_RESET_ON_BOOT` to preserve legacy wiring compatibility.
* **MCU.h Mapping:**
    * **ATmega328/168:** Mapped to **PB2 (Pin D10)**.
    * **ATmega32u4:** Mapped to **PF7 (Pin A0)**.
* **PSNee.ino:** Injected the sync pulse inside the initialization phase, ensuring the pin is restored to high impedance (`INPUT`) immediately after to avoid interference.
* **Diagrams Updated:** Updated the **PM-41 (PSOne Slim)** and Arduino pinout JPGs to include the new reset point.

## Validation & Impact
* **Hardware Tested:** European PSOne **SCPH-102** (PM-41 board) and Japanese **SCPH-5500**.
* **Stability:** Tested with the "problematic" **ATmega328PB** variants; the sync pulse completely eliminates the sync issues previously documented.
* **Bootloader Preservation:** Tested that this mechanism now allows users to keep the standard bootloader (no ISP flashing required), as the console will wait for the bootloader timeout to finish.

* **Results:** I had **100% success** on cold boots using original out-of-region discs in those two models (PsNee 8.6.2 + ATmega328PB with Bootloader flashed via built-in USB).

* **Known Limitations:** While cold boot BIOS patching has been improved, manual resets remain "hit & miss" on Japanese FAT boards due to potential residual hardware states. A full power cycle is still recommended for successful BIOS patching on these models.